### PR TITLE
Allow independent configuration of min SLAS and PAS site usage

### DIFF
--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -37,7 +37,8 @@ def assign_sites(
     gene_models_gff: pathlib.Path,
     slas_pas_sites_gff: pathlib.Path,
     strip_existing: bool,
-    min_usage: int = 4,
+    min_slas_usage: int = 4,
+    min_pas_usage: int = 2,
 ):
     gene_models = geffa.GffFile(
         gene_models_gff, ignore_unknown_feature_types=True)
@@ -91,11 +92,11 @@ def assign_sites(
     for seqreg in gene_models.sequence_regions.values():
         SLAS_to_search = [
             SLAS for SLAS in seqreg.nodes_of_type(geffa.geffa.SLASNode)
-            if int(SLAS.attributes["usage"]) >= min_usage
+            if int(SLAS.attributes["usage"]) >= min_slas_usage
         ]
         PAS_to_search = [
             PAS for PAS in seqreg.nodes_of_type(geffa.geffa.PASNode)
-            if int(PAS.attributes["usage"]) >= min_usage
+            if int(PAS.attributes["usage"]) >= min_pas_usage
         ]
         CDS_to_search_SLAS = [
             mRNA.CDS_children()[0]

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -206,11 +206,21 @@ def slapassign_main():
         default=False,
     )
     parser.add_argument(
-        '--min-usage', '-m',
+        '--min-slas-usage', '-m',
         help=(
-            "When assigning sites to genes, if SLAS / PAS sites are between a "
+            "When assigning sites to genes, if SLAS sites are between a "
             "CDS and a site to be assigned, only consider those with a "
             "minimum usage count. (default 4)"
+        ),
+        type=int,
+        default=4,
+    )
+    parser.add_argument(
+        '--min-pas-usage', '-n',
+        help=(
+            "When assigning sites to genes, if PAS sites are between a "
+            "CDS and a site to be assigned, only consider those with a "
+            "minimum usage count. (default 2)"
         ),
         type=int,
         default=4,
@@ -232,7 +242,8 @@ def slapassign_main():
         args.gene_models_gff,
         args.slas_pas_gff,
         args.strip_existing,
-        min_usage=args.min_usage,
+        min_slas_usage=args.min_slas_usage,
+        min_pas_usage=args.min_pas_usage,
     )
     gff.save('/dev/stdout')
 


### PR DESCRIPTION
SLAS and PAS site usage have very different distributions (SLASs more concentrated on a few sites, PAS more dispersed), so allow separate configuration of minimum SLAS and PAS site usage for accepting/assigning to genes.

Also, pre-emptively, change default minimum PAS usage to half that of the SLAS (2 instead of 4)