### PR TITLE
Assign SLASs and PASs even if within CDS

### DIFF
--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -113,12 +113,12 @@ def assign_sites(
                         (
                             (slas.strand == '+') and
                             (feature.strand == '+') and
-                            (feature.start > slas.end)
+                            (feature.end > slas.end)
                         ) or
                         (
                             (slas.strand == '-') and
                             (feature.strand == '-') and
-                            (feature.end < slas.start)
+                            (feature.start < slas.start)
                         )
                     )
                 ),
@@ -148,11 +148,11 @@ def assign_sites(
                         (
                             (pas.strand == '+') and
                             (feature.strand == '+') and
-                            (feature.end < pas.start)
+                            (feature.start < pas.start)
                         ) or (
                             (pas.strand == '-') and
                             (feature.strand == '-') and
-                            (feature.start > pas.end)
+                            (feature.end > pas.end)
                         )
                     )
                 ),
@@ -212,7 +212,7 @@ def identify_UTRs(
                     (mRNA.strand == '+' and CDSs[0].start < slas.end) or
                     (mRNA.strand == '-' and CDSs[0].end > slas.start)
                 ):
-                    logger.warning(
+                    logger.debug(
                         f"SLAS {slas.attributes['ID']} was assigned wrongly, "
                         "it is behind the start of the CDS. Skipping.")
                 else:
@@ -224,7 +224,7 @@ def identify_UTRs(
                     (mRNA.strand == '+' and CDSs[-1].end > pas.start) or
                     (mRNA.strand == '-' and CDSs[-1].start < pas.end)
                 ):
-                    logger.warning(
+                    logger.debug(
                         f"PAS {pas.attributes['ID']} was assigned wrongly, "
                         "it comes before the start of the CDS. Skipping.")
                 else:


### PR DESCRIPTION
It would be nice to retain SLASs/PASs within a CDS - if we trust the CDS then they certainly can't be the true SLAS/PAS, but it could be used to refine gene models.

Changed to assign SLASs upstream of the _end_ of a CDS, assign PASs downstream of the _start_ of the CDS. CDS-internal PASs/SLASs do not contribute to UTR assignment, so no overall behaviour change. Changed that warning to a debug message, as it's not useful to spam to a user as it's intended behaviour.

Hopefully looks correct...