### PR TITLE
Adaptive SLAS/PAS assignment

### DIFF
--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -46,7 +46,7 @@ def assign_sites(
     gene_models_gff: pathlib.Path,
     slas_pas_sites_gff: pathlib.Path,
     strip_existing: bool,
-    min_slas_usage: int = 4,
+    min_slas_usage: int = 2,
     min_pas_usage: int = 2,
 ):
     gene_models = geffa.GffFile(

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -113,12 +113,16 @@ def assign_sites(
                         (
                             (slas.strand == '+') and
                             (feature.strand == '+') and
-                            (feature.start > slas.end)
+                            (feature.start > slas.end) and
+                            (feature.type == 'CDS' or feature.type == 'PAS' and
+                                int(feature.attributes['usage']) < int(slas.attributes['usage']))
                         ) or
                         (
                             (slas.strand == '-') and
                             (feature.strand == '-') and
-                            (feature.end < slas.start)
+                            (feature.end < slas.start) and
+                            (feature.type == 'CDS' or feature.type == 'PAS' and
+                                int(feature.attributes['usage']) < int(slas.attributes['usage']))
                         )
                     )
                 ),
@@ -148,11 +152,15 @@ def assign_sites(
                         (
                             (pas.strand == '+') and
                             (feature.strand == '+') and
-                            (feature.end < pas.start)
+                            (feature.end < pas.start) and
+                            (feature.type == 'CDS' or feature.type == 'SLAS' and
+                                int(feature.attributes['usage']) < int(pas.attributes['usage']))
                         ) or (
                             (pas.strand == '-') and
                             (feature.strand == '-') and
-                            (feature.start > pas.end)
+                            (feature.start > pas.end) and
+                            (feature.type == 'CDS' or feature.type == 'SLAS' and
+                                int(feature.attributes['usage']) < int(pas.attributes['usage']))
                         )
                     )
                 ),

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -48,6 +48,7 @@ def assign_sites(
     strip_existing: bool,
     min_slas_usage: int = 2,
     min_pas_usage: int = 2,
+    min_usage_factor: float = 0.5
 ):
     gene_models = geffa.GffFile(
         gene_models_gff, ignore_unknown_feature_types=True)
@@ -115,14 +116,16 @@ def assign_sites(
                             (feature.strand == '+') and
                             (feature.start > slas.end) and
                             (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) < int(slas.attributes['usage']))
+                                int(feature.attributes['usage']) <
+                                int(slas.attributes['usage']) * min_usage_factor)
                         ) or
                         (
                             (slas.strand == '-') and
                             (feature.strand == '-') and
                             (feature.end < slas.start) and
                             (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) < int(slas.attributes['usage']))
+                                int(feature.attributes['usage']) <
+                                int(slas.attributes['usage']) * min_usage_factor)
                         )
                     )
                 ),
@@ -154,13 +157,15 @@ def assign_sites(
                             (feature.strand == '+') and
                             (feature.end < pas.start) and
                             (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) < int(pas.attributes['usage']))
+                                int(feature.attributes['usage']) <
+                                int(pas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (pas.strand == '-') and
                             (feature.strand == '-') and
                             (feature.start > pas.end) and
                             (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) < int(pas.attributes['usage']))
+                                int(feature.attributes['usage']) <
+                                int(pas.attributes['usage']) * min_usage_factor)
                         )
                     )
                 ),

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -113,19 +113,29 @@ def assign_sites(
                     if (
                         (
                             (slas.strand == '+') and
+                            (feature.type == 'PAS') and
                             (feature.strand == '+') and
                             (feature.start > slas.end) and
-                            (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) >
+                            (int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']) * min_usage_factor)
                         ) or
                         (
                             (slas.strand == '-') and
+                            (feature.type == 'PAS') and
                             (feature.strand == '-') and
                             (feature.end < slas.start) and
-                            (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) >
+                            (int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']) * min_usage_factor)
+                        ) or
+                        (
+                            (feature.type == 'CDS') and
+                            (feature.strand == '+') and
+                            (feature.start > slas.end)
+                        ) or
+                        (
+                            (feature.type == 'CDS') and
+                            (feature.strand == '-') and
+                            (feature.end < slas.start)
                         )
                     )
                 ),
@@ -144,6 +154,11 @@ def assign_sites(
                 logger.info(
                     f"Closest node to {slas.attributes['ID']} is a PAS, no "
                     "CDS could be assigned.")
+            elif closest_node.strand != slas.strand:
+                logger.info(
+                    f"Closest node to {slas.attributes['ID']} is on the "
+                    "opposite strand, no CDS could be assigned."
+                )
             else:
                 slas.add_parent(closest_node.parents[0].parents[0])
 
@@ -154,18 +169,26 @@ def assign_sites(
                     if (
                         (
                             (pas.strand == '+') and
+                            (feature.type == 'SLAS') and
                             (feature.strand == '+') and
                             (feature.end < pas.start) and
-                            (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) >
+                            (int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (pas.strand == '-') and
+                            (feature.type == 'SLAS') and
                             (feature.strand == '-') and
                             (feature.start > pas.end) and
-                            (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) >
+                            (int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']) * min_usage_factor)
+                        ) or (
+                            (feature.type == 'CDS') and
+                            (feature.strand == '+') and
+                            (feature.end < pas.start)
+                        ) or (
+                            (feature.type == 'CDS') and
+                            (feature.strand == '-') and
+                            (feature.start > pas.end)
                         )
                     )
                 ),
@@ -184,6 +207,11 @@ def assign_sites(
                 logger.info(
                     f"Closest node to {pas.attributes['ID']} is a SLAS, no "
                     "CDS could be assigned."
+                )
+            elif closest_node.strand != pas.strand:
+                logger.info(
+                    f"Closest node to {pas.attributes['ID']} is on the "
+                    "opposite strand, no CDS could be assigned."
                 )
             else:
                 pas.add_parent(closest_node.parents[0].parents[0])

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -116,7 +116,7 @@ def assign_sites(
                             (feature.strand == '+') and
                             (feature.start > slas.end) and
                             (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) <
+                                int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']) * min_usage_factor)
                         ) or
                         (
@@ -124,7 +124,7 @@ def assign_sites(
                             (feature.strand == '-') and
                             (feature.end < slas.start) and
                             (feature.type == 'CDS' or feature.type == 'PAS' and
-                                int(feature.attributes['usage']) <
+                                int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']) * min_usage_factor)
                         )
                     )
@@ -157,14 +157,14 @@ def assign_sites(
                             (feature.strand == '+') and
                             (feature.end < pas.start) and
                             (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) <
+                                int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (pas.strand == '-') and
                             (feature.strand == '-') and
                             (feature.start > pas.end) and
                             (feature.type == 'CDS' or feature.type == 'SLAS' and
-                                int(feature.attributes['usage']) <
+                                int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']) * min_usage_factor)
                         )
                     )

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -256,20 +256,20 @@ def slapassign_main():
         help=(
             "When assigning sites to genes, if SLAS sites are between a "
             "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 4)"
+            "minimum usage count. (default 2)"
         ),
         type=int,
-        default=4,
+        default=2,
     )
     parser.add_argument(
         '--min-pas-usage', '-n',
         help=(
             "When assigning sites to genes, if PAS sites are between a "
             "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 4)"
+            "minimum usage count. (default 2)"
         ),
         type=int,
-        default=4,
+        default=2,
     )
     parser.add_argument(
         '-v',

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -254,9 +254,8 @@ def slapassign_main():
     parser.add_argument(
         '--min-slas-usage', '-m',
         help=(
-            "When assigning sites to genes, if SLAS sites are between a "
-            "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 2)"
+            "When assigning sites to genes, discard SLAS sites with a "
+            "usage count below this value. (default 2)"
         ),
         type=int,
         default=2,
@@ -264,12 +263,22 @@ def slapassign_main():
     parser.add_argument(
         '--min-pas-usage', '-n',
         help=(
-            "When assigning sites to genes, if PAS sites are between a "
-            "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 2)"
+            "When assigning sites to genes, discard PAS sites with a "
+            "usage count below this value. (default 2)"
         ),
         type=int,
         default=2,
+    )
+    parser.add_argument(
+        '--min-usage-factor',
+        help=(
+            "When assigning sites to genes, block assignment of a SLAS "
+            "to a CDS if an intervening PAS site has a usage count "
+            "above this factor times the usage of the SLAS site to be "
+            "assigned. And, vice versa for PAS sites. (default 0.5)"
+        ),
+        type=float,
+        default=0.5,
     )
     parser.add_argument(
         '-v',
@@ -290,6 +299,7 @@ def slapassign_main():
         args.strip_existing,
         min_slas_usage=args.min_slas_usage,
         min_pas_usage=args.min_pas_usage,
+        min_usage_factor=args.min_usage_factor,
     )
     gff.save('/dev/stdout')
 


### PR DESCRIPTION
Attempt to make SLAS/PAS assignment to CDSs less dependent on hard threshold usage rates, to try to make assignment of long UTRs more likely, while also not preventing assignment of UTRs to low abundance mRNAs.

1) Updates SLAS/PAS assignment to only be blocked by intervening PAS/SLAS sites respectively which have greater usage than the candidate site for assignment.
2) Change default minimum SLAS/PAS usage to 2, ie. retain all sites used at least twice as a very low stringency noise filter, with those retained to be tested as in 1)
3) Add a min usage factor (float) for user adjustable assignment blocking behaviour. factor 0 means intervening PAS/SLAS sites will never block assignment, factor big (larger than any SLAS/PAS usage) will mean any PAS/SLAS site, even with low usage, will block assignment.

Issues:
5' UTRs for genes at the start of a transcription unit and 3' UTRs for genes at the end of a transcription unit tend to not be assigned UTRs. Presumably because very distant SLASs/PASs end up assigned to the gene, making a very long resulting UTR which is rejected.
Attempted to fix by CDSs on the opposite strand blocking assignment of candidate SLASs/PASs, currently broken (breaks all assignment). Other options would be distance dropoff (eg. only allow assignment within some max distance, or weight usage by distance `e^(1/distance_scale) * site_usage`).