### PR TITLE
Adaptive SLAS/PAS assignment, take 2

### DIFF
--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -48,6 +48,7 @@ def assign_sites(
     strip_existing: bool,
     min_slas_usage: int = 2,
     min_pas_usage: int = 2,
+    min_usage_factor: float = 1.0
 ):
     gene_models = geffa.GffFile(
         gene_models_gff, ignore_unknown_feature_types=True)
@@ -115,13 +116,13 @@ def assign_sites(
                             (slas.strand == '+') and
                             (feature.end > slas.end) and
                             (int(feature.attributes['usage']) >
-                                int(slas.attributes['usage']))
+                                int(slas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (feature.type == 'PAS') and
                             (slas.strand == '-') and
                             (feature.start < slas.start) and
                             (int(feature.attributes['usage']) >
-                                int(slas.attributes['usage']))
+                                int(slas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (feature.type == 'CDS') and
                             (slas.strand == '+') and
@@ -163,13 +164,13 @@ def assign_sites(
                             (pas.strand == '+') and
                             (feature.start < pas.start) and
                             (int(feature.attributes['usage']) >
-                                int(pas.attributes['usage']))
+                                int(pas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (feature.type == 'SLAS') and
                             (pas.strand == '-') and
                             (feature.end > pas.end) and
                             (int(feature.attributes['usage']) >
-                                int(pas.attributes['usage']))
+                                int(pas.attributes['usage']) * min_usage_factor)
                         ) or (
                             (feature.type == "CDS") and
                             (pas.strand == '+') and

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -113,14 +113,12 @@ def assign_sites(
                         (
                             (feature.type == 'PAS') and
                             (slas.strand == '+') and
-                            (feature.strand == '+') and
                             (feature.end > slas.end) and
                             (int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']))
                         ) or (
                             (feature.type == 'PAS') and
                             (slas.strand == '-') and
-                            (feature.strand == '-') and
                             (feature.start < slas.start) and
                             (int(feature.attributes['usage']) >
                                 int(slas.attributes['usage']))
@@ -163,14 +161,12 @@ def assign_sites(
                         (
                             (feature.type == 'SLAS') and
                             (pas.strand == '+') and
-                            (feature.strand == '+') and
                             (feature.start < pas.start) and
                             (int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']))
                         ) or (
                             (feature.type == 'SLAS') and
                             (pas.strand == '-') and
-                            (feature.strand == '-') and
                             (feature.end > pas.end) and
                             (int(feature.attributes['usage']) >
                                 int(pas.attributes['usage']))

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -46,7 +46,7 @@ def assign_sites(
     gene_models_gff: pathlib.Path,
     slas_pas_sites_gff: pathlib.Path,
     strip_existing: bool,
-    min_slas_usage: int = 4,
+    min_slas_usage: int = 2,
     min_pas_usage: int = 2,
 ):
     gene_models = geffa.GffFile(

--- a/src/slapquant/assign.py
+++ b/src/slapquant/assign.py
@@ -111,11 +111,26 @@ def assign_sites(
                     feature for feature in nodes_SLAS
                     if (
                         (
+                            (feature.type == 'PAS') and
+                            (slas.strand == '+') and
+                            (feature.strand == '+') and
+                            (feature.end > slas.end) and
+                            (int(feature.attributes['usage']) >
+                                int(slas.attributes['usage']))
+                        ) or (
+                            (feature.type == 'PAS') and
+                            (slas.strand == '-') and
+                            (feature.strand == '-') and
+                            (feature.start < slas.start) and
+                            (int(feature.attributes['usage']) >
+                                int(slas.attributes['usage']))
+                        ) or (
+                            (feature.type == 'CDS') and
                             (slas.strand == '+') and
                             (feature.strand == '+') and
                             (feature.end > slas.end)
-                        ) or
-                        (
+                        ) or (
+                            (feature.type == 'CDS') and
                             (slas.strand == '-') and
                             (feature.strand == '-') and
                             (feature.start < slas.start)
@@ -146,10 +161,26 @@ def assign_sites(
                     feature for feature in nodes_PAS
                     if (
                         (
+                            (feature.type == 'SLAS') and
+                            (pas.strand == '+') and
+                            (feature.strand == '+') and
+                            (feature.start < pas.start) and
+                            (int(feature.attributes['usage']) >
+                                int(pas.attributes['usage']))
+                        ) or (
+                            (feature.type == 'SLAS') and
+                            (pas.strand == '-') and
+                            (feature.strand == '-') and
+                            (feature.end > pas.end) and
+                            (int(feature.attributes['usage']) >
+                                int(pas.attributes['usage']))
+                        ) or (
+                            (feature.type == "CDS") and
                             (pas.strand == '+') and
                             (feature.strand == '+') and
                             (feature.start < pas.start)
                         ) or (
+                            (feature.type == "CDS") and
                             (pas.strand == '-') and
                             (feature.strand == '-') and
                             (feature.end > pas.end)

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -256,20 +256,20 @@ def slapassign_main():
         help=(
             "When assigning sites to genes, if SLAS sites are between a "
             "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 4)"
+            "minimum usage count. (default 2)"
         ),
         type=int,
-        default=4,
+        default=2,
     )
     parser.add_argument(
         '--min-pas-usage', '-n',
         help=(
             "When assigning sites to genes, if PAS sites are between a "
             "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 4)"
+            "minimum usage count. (default 2)"
         ),
         type=int,
-        default=4,
+        default=2,
     )
     parser.add_argument(
         '-v',

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -254,9 +254,8 @@ def slapassign_main():
     parser.add_argument(
         '--min-slas-usage', '-m',
         help=(
-            "When assigning sites to genes, if SLAS sites are between a "
-            "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 2)"
+            "When assigning sites to genes, discard SLAS sites with a "
+            "usage count below this value. (default 2)"
         ),
         type=int,
         default=2,
@@ -264,9 +263,8 @@ def slapassign_main():
     parser.add_argument(
         '--min-pas-usage', '-n',
         help=(
-            "When assigning sites to genes, if PAS sites are between a "
-            "CDS and a site to be assigned, only consider those with a "
-            "minimum usage count. (default 2)"
+            "When assigning sites to genes, discard PAS sites with a "
+            "usage count below this value. (default 2)"
         ),
         type=int,
         default=2,

--- a/src/slapquant/cli.py
+++ b/src/slapquant/cli.py
@@ -270,6 +270,17 @@ def slapassign_main():
         default=2,
     )
     parser.add_argument(
+        '--min-usage-factor',
+        help=(
+            "When assigning sites to genes, block assignment of a SLAS "
+            "to a CDS if an intervening PAS site has a relative usage "
+            "of at least min usage factor. And, vice versa for PAS sites. "
+            "(default 1.0)"
+        ),
+        type=float,
+        default=1.0,
+    )
+    parser.add_argument(
         '-v',
         '--verbose',
         help="Give more info about the process.",
@@ -288,6 +299,7 @@ def slapassign_main():
         args.strip_existing,
         min_slas_usage=args.min_slas_usage,
         min_pas_usage=args.min_pas_usage,
+        min_usage_factor=args.min_usage_factor,
     )
     gff.save('/dev/stdout')
 


### PR DESCRIPTION
Second attempt on this change. Key difference is that it works well for ends of transcription units, by blocking PAS/SLAS assignment with high usage sites on _either_ strand. Implemented with inverted `--min-usage-factor` value behaviour.